### PR TITLE
Integrate orchestrator via dependency injection

### DIFF
--- a/ai_serp_keyword_research/api/dependencies.py
+++ b/ai_serp_keyword_research/api/dependencies.py
@@ -1,0 +1,13 @@
+from ai_serp_keyword_research.main import (
+    get_cache_service,
+    get_db_session,
+    get_credentials,
+    get_agent_orchestrator,
+)
+
+__all__ = [
+    "get_cache_service",
+    "get_db_session",
+    "get_credentials",
+    "get_agent_orchestrator",
+]

--- a/ai_serp_keyword_research/api/routes/analyze.py
+++ b/ai_serp_keyword_research/api/routes/analyze.py
@@ -4,13 +4,10 @@ Analyze endpoints for the AI SERP Keyword Research Agent API.
 This module provides endpoints for analyzing search terms and generating SEO recommendations.
 """
 
-import asyncio
 import uuid
 from datetime import datetime
-from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks, Request
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Depends, BackgroundTasks, Request
 
 from ai_serp_keyword_research.api.schemas.request import AnalyzeRequest
 from ai_serp_keyword_research.api.schemas.response import AnalyzeResponse, ErrorResponse
@@ -20,7 +17,8 @@ from ai_serp_keyword_research.data.repositories import SearchAnalysisRepository
 from ai_serp_keyword_research.services.cache import CacheService
 from ai_serp_keyword_research.orchestration.multi_agent_orchestrator import SerpKeywordAnalysisOrchestrator
 from ai_serp_keyword_research.tracing import trace
-from ai_serp_keyword_research.utils.logging import app_logger, CorrelationIDFilter, LogContext
+from ai_serp_keyword_research.utils.logging import app_logger, CorrelationIDFilter
+from ai_serp_keyword_research.api.dependencies import get_agent_orchestrator
 
 # Create router
 router = APIRouter(tags=["Analysis"])
@@ -39,7 +37,7 @@ async def analyze_keyword(
     cache_service: CacheService = Depends(),
     analysis_repository: SearchAnalysisRepository = Depends(),
     pipeline: SerpAnalysisPipeline = Depends(),
-    orchestrator: SerpKeywordAnalysisOrchestrator = Depends(),
+    orchestrator: SerpKeywordAnalysisOrchestrator = Depends(get_agent_orchestrator),
 ) -> AnalyzeResponse:
     """
     Analyze a search term to extract SEO insights and generate recommendations.

--- a/ai_serp_keyword_research/main.py
+++ b/ai_serp_keyword_research/main.py
@@ -43,6 +43,7 @@ from ai_serp_keyword_research.data.repositories.base import create_db_session
 from ai_serp_keyword_research.tracing import configure_tracing, trace
 from ai_serp_keyword_research.metrics import configure_metrics
 from ai_serp_keyword_research.metrics.performance import get_performance_monitor
+from ai_serp_keyword_research.orchestration.multi_agent_orchestrator import SerpKeywordAnalysisOrchestrator
 from ai_serp_keyword_research.utils.logging import app_logger
 from ai_serp_keyword_research.utils.env_validator import validate_environment, EnvironmentValidationError
 from ai_serp_keyword_research.security import get_credential_manager
@@ -156,6 +157,9 @@ async def startup_event():
     # Set up database session
     db_url = credential_manager.get_connection_string("DATABASE") or os.getenv("DATABASE_URL", "sqlite:///./test.db")
     app.state.db_session = await create_db_session(db_url)
+
+    # Initialize the multi-agent orchestrator
+    app.state.orchestrator = SerpKeywordAnalysisOrchestrator()
     
     # Set up tracing
     configure_tracing_enabled = os.getenv("ENABLE_TRACING", "false").lower() == "true"
@@ -253,4 +257,8 @@ def get_db_session():
 
 def get_credentials():
     """Get the credential manager for dependency injection."""
-    return app.state.credential_manager 
+    return app.state.credential_manager
+
+def get_agent_orchestrator() -> SerpKeywordAnalysisOrchestrator:
+    """Get the multi-agent orchestrator instance."""
+    return app.state.orchestrator


### PR DESCRIPTION
## Summary
- clean unused imports in analysis router
- provide `get_agent_orchestrator` dependency and register orchestrator on startup
- expose dependency helpers through `api/dependencies`
- inject orchestrator via `Depends(get_agent_orchestrator)`

## Testing
- `pytest -q` *(fails: `pytest` not found)*