### PR TITLE
Add basic SERP agents and usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # keyword-analyze
+
+This package contains a minimal framework for analyzing search engine results
+pages (SERPs). The `SerpKeywordAnalysisOrchestrator` coordinates multiple
+agent functions that process different aspects of the SERP data.
+
+## Example Usage
+
+```python
+import asyncio
+from ai_serp_keyword_research.orchestration.multi_agent_orchestrator import (
+    SerpKeywordAnalysisOrchestrator,
+)
+from ai_serp_keyword_research.agents.basic_agents import (
+    serp_agent,
+    intent_agent,
+    market_gap_agent,
+)
+
+async def main():
+    orchestrator = SerpKeywordAnalysisOrchestrator(
+        serp_agent=serp_agent,
+        intent_agent=intent_agent,
+        market_gap_agent=market_gap_agent,
+    )
+
+    results = await orchestrator.analyze(
+        "python async",
+        serp_data={"results": []},
+        intent_analysis={"intent": "learning"},
+        market_gap={"gap": "tutorials"},
+    )
+    print(results)
+
+asyncio.run(main())
+```

--- a/ai_serp_keyword_research/agents/basic_agents.py
+++ b/ai_serp_keyword_research/agents/basic_agents.py
@@ -1,0 +1,58 @@
+import asyncio
+
+async def serp_agent(search_term, serp_data):
+    """Process SERP data.
+
+    Parameters
+    ----------
+    search_term : str
+        The search term that produced the SERP.
+    serp_data : Any
+        Raw SERP results to process.
+
+    Returns
+    -------
+    Any
+        The processed SERP data.
+    """
+    # In a real implementation some asynchronous processing would occur.
+    await asyncio.sleep(0)
+    return serp_data
+
+
+async def intent_agent(search_term, intent_analysis):
+    """Handle search intent analysis.
+
+    Parameters
+    ----------
+    search_term : str
+        The search term under analysis.
+    intent_analysis : Any
+        Data describing the search intent.
+
+    Returns
+    -------
+    Any
+        The intent analysis results.
+    """
+    await asyncio.sleep(0)
+    return intent_analysis
+
+
+async def market_gap_agent(search_term, market_gap):
+    """Process market gap information.
+
+    Parameters
+    ----------
+    search_term : str
+        The search term under analysis.
+    market_gap : Any
+        Information describing gaps in the market.
+
+    Returns
+    -------
+    Any
+        The processed market gap data.
+    """
+    await asyncio.sleep(0)
+    return market_gap


### PR DESCRIPTION
## Summary
- provide async SERP agent helpers
- make `agents` a package
- expand README with example using `SerpKeywordAnalysisOrchestrator`

## Testing
- `python -m py_compile ai_serp_keyword_research/agents/basic_agents.py ai_serp_keyword_research/orchestration/multi_agent_orchestrator.py`